### PR TITLE
Improve OpenAI setup instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 notes.txt
 .env
+build/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This project is a simple Python application that records voice notes, summarizes
 - Python 3.10+
 - `openai` for interacting with the LLM
 - `speechrecognition` for voice input
+- `python-dotenv` for loading environment variables
 
 Install dependencies with:
 
@@ -14,11 +15,16 @@ Install dependencies with:
 pip install .
 ```
 
-Set your OpenAI API key in the environment:
+The `pip install` command will create `build/` and `*.egg-info` folders. These
+are ignored by Git via `.gitignore` and can be safely deleted if desired.
+
+Create a `.env` file in the project root containing your OpenAI API key:
 
 ```bash
-export OPENAI_API_KEY=your-key-here
+OPENAI_API_KEY=your-key-here
 ```
+
+The application will automatically load this file using `python-dotenv`.
 
 ## Usage
 
@@ -35,3 +41,13 @@ python -m note_app.main query "What do I need to buy?"
 ```
 
 Notes are stored in `notes.txt` in the project directory.
+
+## Testing the OpenAI API
+
+You can verify your API key and connectivity by running:
+
+```bash
+python openai_test.py
+```
+
+This script makes a simple request to OpenAI and prints the response.

--- a/note_app/llm_interface.py
+++ b/note_app/llm_interface.py
@@ -4,6 +4,7 @@ import os
 from dataclasses import dataclass
 
 import openai
+from dotenv import load_dotenv
 
 
 @dataclass
@@ -13,6 +14,7 @@ class LLMInterface:
     model: str = "gpt-3.5-turbo"
 
     def __post_init__(self) -> None:
+        load_dotenv()
         api_key = os.getenv("OPENAI_API_KEY")
         if not api_key:
             raise EnvironmentError("OPENAI_API_KEY environment variable not set")

--- a/openai_test.py
+++ b/openai_test.py
@@ -1,10 +1,12 @@
 import os
 
 import openai
+from dotenv import load_dotenv
 
 
 def main() -> None:
     """Make a simple call to the OpenAI API and print the response."""
+    load_dotenv()
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         raise EnvironmentError("OPENAI_API_KEY environment variable not set")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "openai",
-    "SpeechRecognition"
+    "SpeechRecognition",
+    "python-dotenv",
 ]
 


### PR DESCRIPTION
## Summary
- add `python-dotenv` to dependencies
- ignore build and `*.egg-info` artifacts
- load `.env` variables automatically in `LLMInterface` and `openai_test.py`
- document using `.env` for API keys and how to test the connection

## Testing
- `pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_6848021f0bf883308d3eed0fb226c879