### PR TITLE
Fix missing dependency and update model

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 This project is a simple Python application that records voice notes, summarizes them using an LLM (such as OpenAI's GPT), and saves the summarized notes with a timestamp. You can also query existing notes using natural language.
 
+The application defaults to the `gpt-4.1-nano` model for all LLM calls.
+
 ## Requirements
 
 - Python 3.10+
 - `openai` for interacting with the LLM
 - `speechrecognition` for voice input
+- `pyaudio` for microphone access
 - `python-dotenv` for loading environment variables
 
 Install dependencies with:
@@ -14,6 +17,10 @@ Install dependencies with:
 ```bash
 pip install .
 ```
+
+If the installation fails on Windows, download a prebuilt PyAudio wheel from
+[the unofficial binaries site](https://www.lfd.uci.edu/~gohlke/pythonlibs/#pyaudio)
+and install it with `pip install <wheel-filename>`.
 
 The `pip install` command will create `build/` and `*.egg-info` folders. These
 are ignored by Git via `.gitignore` and can be safely deleted if desired.

--- a/note_app/llm_interface.py
+++ b/note_app/llm_interface.py
@@ -11,7 +11,7 @@ from dotenv import load_dotenv
 class LLMInterface:
     """Interface to interact with an LLM, e.g. OpenAI GPT."""
 
-    model: str = "gpt-3.5-turbo"
+    model: str = "gpt-4.1-nano"
 
     def __post_init__(self) -> None:
         load_dotenv()

--- a/openai_test.py
+++ b/openai_test.py
@@ -12,7 +12,7 @@ def main() -> None:
         raise EnvironmentError("OPENAI_API_KEY environment variable not set")
     client = OpenAI(api_key=api_key)
     response = client.chat.completions.create(
-        model="gpt-3.5-turbo",
+        model="gpt-4.1-nano",
         messages=[{"role": "user", "content": "Hello"}],
     )
     print(response.choices[0].message.content.strip())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "openai>=1.0.0",
     "SpeechRecognition>=3.10.0",
+    "PyAudio>=0.2.14",
     "python-dotenv>=1.0.0",
 ]
 


### PR DESCRIPTION
## Summary
- add PyAudio to dependencies
- document PyAudio installation instructions
- switch default model to `gpt-4.1-nano`
- update example script to use the new model

## Testing
- `python -m note_app.main --help`
- `python openai_test.py` *(fails: OPENAI_API_KEY environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_68480602809883309fad7c8702dada3b