### PR TITLE
Refactor voice recorder and ignore audio files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ notes.txt
 .env
 build/
 *.egg-info/
+*.wav

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ python -m note_app.main record
 The recorder now waits for you to press **Enter** to start and again to stop,
 so it won't cut you off mid-sentence. 
 
-During recording a file named `latest_recording.wav` is saved in the project
+During recording a file named `last_recording.wav` is saved in the project
 directory. This contains the raw audio that is sent to the LLM, which can be
 useful for debugging.
 

--- a/note_app/voice_recorder.py
+++ b/note_app/voice_recorder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from threading import Event, Thread
 from typing import List
 
 import speech_recognition as sr
@@ -8,40 +9,50 @@ import speech_recognition as sr
 class VoiceRecorder:
     """Record audio from the microphone and convert it to text."""
 
-    def __init__(self, save_path: str = "latest_recording.wav") -> None:
+    def __init__(self, save_path: str = "last_recording.wav") -> None:
         self.recognizer = sr.Recognizer()
         self.save_path = save_path
 
     def _record_audio(self) -> sr.AudioData:
-        """Record audio until the user presses Enter again."""
+        """Record audio after the user presses Enter to start and stop."""
         with sr.Microphone() as source:
-            chunks: List[sr.AudioData] = []
-
-            def callback(_: sr.Recognizer, audio: sr.AudioData) -> None:
-                chunks.append(audio)
+            print("Calibrating ambient noise...")
+            self.recognizer.adjust_for_ambient_noise(source, duration=1)
 
             print("Press Enter to start recording...")
             input()
             print("Recording... press Enter to stop.")
 
-            stop_listening = self.recognizer.listen_in_background(
-                source, callback
-            )
-            input()
-            stop_listening(wait_for_stop=False)
+            stop_event = Event()
+            audio_frames: List[bytes] = []
+            sample_rate = source.SAMPLE_RATE
+            sample_width = source.SAMPLE_WIDTH
 
-            if not chunks:
+            def wait_for_stop() -> None:
+                input()
+                stop_event.set()
+
+            Thread(target=wait_for_stop, daemon=True).start()
+
+            while not stop_event.is_set():
+                try:
+                    audio = self.recognizer.listen(
+                        source, timeout=1, phrase_time_limit=1
+                    )
+                    audio_frames.append(audio.get_raw_data())
+                except sr.WaitTimeoutError:
+                    pass
+
+            if not audio_frames:
                 raise RuntimeError("No audio captured")
 
-            sample_rate = chunks[0].sample_rate
-            sample_width = chunks[0].sample_width
-            raw_data = b"".join(chunk.get_raw_data() for chunk in chunks)
-            audio = sr.AudioData(raw_data, sample_rate, sample_width)
+            raw_data = b"".join(audio_frames)
+            audio_data = sr.AudioData(raw_data, sample_rate, sample_width)
 
-            with open(self.save_path, "wb") as f:
-                f.write(audio.get_wav_data())
+            with open(self.save_path, "wb") as file:
+                file.write(audio_data.get_wav_data())
 
-            return audio
+            return audio_data
 
     def record_text(self) -> str:
         """Record from the microphone and return transcribed text."""


### PR DESCRIPTION
## Summary
- refactor `VoiceRecorder` for manual start/stop recording using a thread
- change default recording filename to `last_recording.wav`
- document the new filename in README
- ignore `.wav` audio files via `.gitignore`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684810c7abfc8330a6dfa60bacbe6430