### PR TITLE
Add language option and debug messages

### DIFF
--- a/note_app/main.py
+++ b/note_app/main.py
@@ -34,6 +34,13 @@ def main() -> None:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     record_parser = subparsers.add_parser("record", help="Record a new voice note")
+    record_parser.add_argument(
+        "--language",
+        "-l",
+        choices=["en", "fr"],
+        default="en",
+        help="Recording language: en or fr",
+    )
 
     query_parser = subparsers.add_parser("query", help="Query existing notes")
     query_parser.add_argument("prompt", help="Question about your notes")
@@ -42,7 +49,8 @@ def main() -> None:
 
     llm = LLMInterface()
     notes = NoteManager()
-    recorder = VoiceRecorder()
+    language_code = "fr-FR" if getattr(args, "language", "en") == "fr" else "en-US"
+    recorder = VoiceRecorder(language=language_code)
 
     commands: dict[str, Callable[..., None]] = {
         "record": lambda: record_note(llm, notes, recorder),

--- a/note_app/voice_recorder.py
+++ b/note_app/voice_recorder.py
@@ -9,9 +9,10 @@ import speech_recognition as sr
 class VoiceRecorder:
     """Record audio from the microphone and convert it to text."""
 
-    def __init__(self, save_path: str = "last_recording.wav") -> None:
+    def __init__(self, save_path: str = "last_recording.wav", language: str = "en-US") -> None:
         self.recognizer = sr.Recognizer()
         self.save_path = save_path
+        self.language = language
 
     def _record_audio(self) -> sr.AudioData:
         """Record audio after the user presses Enter to start and stop."""
@@ -51,6 +52,7 @@ class VoiceRecorder:
 
             with open(self.save_path, "wb") as file:
                 file.write(audio_data.get_wav_data())
+            print(f"Audio saved to {self.save_path}")
 
             return audio_data
 
@@ -58,7 +60,9 @@ class VoiceRecorder:
         """Record from the microphone and return transcribed text."""
         audio = self._record_audio()
         try:
-            return self.recognizer.recognize_google(audio)
+            text = self.recognizer.recognize_google(audio, language=self.language)
+            print(f"[DEBUG] Recognized text: {text}")
+            return text
         except sr.UnknownValueError:
             return ""
         except sr.RequestError as exc:


### PR DESCRIPTION
## Summary
- allow setting language for recordings
- print a message when the wav file is saved
- show recognized text for debugging

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6848123ee51883309e47301884575b3e