### PR TITLE
Add voice query option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 This project is a simple Python application that records voice notes, summarizes them using an LLM (such as OpenAI's GPT), and saves the summarized notes with a timestamp. You can also query existing notes using natural language.
 
 The application defaults to the `gpt-4.1-nano` model for all LLM calls.
+When recording or querying by voice you can choose between English and French
+speech recognition. Use the `--language` option with either `en` (default) or
+`fr`.
 
 ## Requirements
 
@@ -35,13 +38,19 @@ The application will automatically load this file using `python-dotenv`.
 
 ## Usage
 
-Record a new voice note:
+Record a new voice note (English):
 
 ```bash
 python -m note_app.main record
 ```
 The recorder now waits for you to press **Enter** to start and again to stop,
-so it won't cut you off mid-sentence. 
+so it won't cut you off mid-sentence.
+
+For French use:
+
+```bash
+python -m note_app.main record --language fr
+```
 
 During recording a file named `last_recording.wav` is saved in the project
 directory. This contains the raw audio that is sent to the LLM, which can be
@@ -52,6 +61,14 @@ Query notes:
 ```bash
 python -m note_app.main query "What do I need to buy?"
 ```
+
+You can also speak the query instead of typing:
+
+```bash
+python -m note_app.main query --voice
+```
+
+As with recording, add `--language fr` to recognise French speech.
 
 Notes are stored in `notes.txt` in the project directory.
 


### PR DESCRIPTION
## Summary
- handle spoken questions using `--voice`
- allow language selection on query command
- document how to choose languages and run voice queries

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6848137c6eb483308d7c17c4ae2c9de7