### PR TITLE
Infer categories automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Record a new voice note (English):
 ```bash
 python -m note_app.main record
 ```
+Categories are inferred automatically from the note text.
 The recorder now waits for you to press **Enter** to start and again to stop,
 so it won't cut you off mid-sentence.
 
@@ -61,6 +62,7 @@ Query notes:
 ```bash
 python -m note_app.main query "What do I need to buy?"
 ```
+The returned lines include the original timestamp and category for each note.
 
 You can also speak the query instead of typing:
 

--- a/note_app/llm_interface.py
+++ b/note_app/llm_interface.py
@@ -35,10 +35,25 @@ class LLMInterface:
         )
         return response.choices[0].message.content.strip()
 
-    def query_notes(self, notes: str, query: str) -> str:
-        """Return only lines from notes relevant to the query."""
+    def infer_category(self, text: str) -> str:
+        """Return a short category describing the text."""
         prompt = (
-            "You are a note assistant. Given the following notes, return only the lines that are relevant to the user's query."
+            "Provide a concise category for the following note. "
+            "Respond with only a short phrase." 
+        )
+        messages = [
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": text},
+        ]
+        response = self.client.chat.completions.create(
+            model=self.model, messages=messages
+        )
+        return response.choices[0].message.content.strip()
+
+    def query_notes(self, notes: str, query: str) -> str:
+        """Return full note lines, with timestamps and categories, relevant to the query."""
+        prompt = (
+            "You are a note assistant. Given the following notes, return only the full original lines (including date and category) that are relevant to the user's query."
         )
         messages = [
             {"role": "system", "content": prompt},

--- a/note_app/note_manager.py
+++ b/note_app/note_manager.py
@@ -11,11 +11,11 @@ class NoteManager:
         self.notes_path = Path(notes_path)
         self.notes_path.touch(exist_ok=True)
 
-    def add_note(self, note_text: str) -> None:
-        """Add a note with a timestamp."""
+    def add_note(self, note_text: str, category: str = "General") -> None:
+        """Add a note with a timestamp and category."""
         timestamp = datetime.now().strftime("%d/%m/%Y %I:%M %p")
         with self.notes_path.open("a", encoding="utf-8") as file:
-            file.write(f"{timestamp} : {note_text}\n")
+            file.write(f"{timestamp} : [{category}] {note_text}\n")
 
     def read_notes(self) -> str:
         """Return all notes as a single string."""


### PR DESCRIPTION
## Summary
- infer category with OpenAI and store note with `[category]`
- remove manual `--category` option
- document automatic categorisation in README

## Testing
- `pip install -e .`
- `pytest -q`
- `python -m note_app.main record --help`
- `python -m note_app.main query --help`


------
https://chatgpt.com/codex/tasks/task_e_68481661524c8330a3dd660c32206c3b