### PR TITLE
Add simple Flask web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,23 @@ Notes are stored in `notes.txt` in the project directory.
 The list of possible categories is read from `categories.txt`. Edit this file to
 control how your notes are classified.
 
+## Web Interface
+
+You can run a simple web interface using Flask:
+
+```bash
+python -m note_app.web_app
+```
+
+Open <http://localhost:5000> in your browser. The site has two main actions:
+
+- **Record Note** – record directly in the browser. The audio is sent to the
+  server, transcribed using Whisper and saved like the command line version.
+- **Query Notes** – ask questions about your notes.
+
+The sidebar lets you edit `notes.txt` and `categories.txt` directly in the
+browser. The layout uses Bootstrap so it works well on mobile devices.
+
 ## Testing the OpenAI API
 
 You can verify your API key and connectivity by running:

--- a/note_app/static/app.js
+++ b/note_app/static/app.js
@@ -1,0 +1,45 @@
+// Recording functionality
+const recordBtn = document.getElementById('record-btn');
+if (recordBtn) {
+  let mediaRecorder;
+  let chunks = [];
+  recordBtn.addEventListener('click', async () => {
+    if (!mediaRecorder || mediaRecorder.state === 'inactive') {
+      chunks = [];
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      mediaRecorder = new MediaRecorder(stream);
+      mediaRecorder.ondataavailable = e => chunks.push(e.data);
+      mediaRecorder.onstop = async () => {
+        const blob = new Blob(chunks, { type: 'audio/webm' });
+        document.getElementById('status').textContent = 'Transcribing...';
+        const fd = new FormData();
+        fd.append('audio', blob, 'recording.webm');
+        const resp = await fetch('/record', { method: 'POST', body: fd });
+        const data = await resp.json();
+        document.getElementById('status').textContent = '';
+        document.getElementById('result').textContent = data.message;
+      };
+      mediaRecorder.start();
+      recordBtn.textContent = 'Stop Recording';
+    } else {
+      mediaRecorder.stop();
+      recordBtn.textContent = 'Start Recording';
+    }
+  });
+}
+
+// Query functionality
+const queryForm = document.getElementById('query-form');
+if (queryForm) {
+  queryForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const query = document.getElementById('query').value;
+    const resp = await fetch('/query', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query })
+    });
+    const data = await resp.json();
+    document.getElementById('query-result').textContent = data.result;
+  });
+}

--- a/note_app/templates/categories.html
+++ b/note_app/templates/categories.html
@@ -1,0 +1,10 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="mt-4">Edit Categories</h2>
+<form method="post">
+  <div class="mb-3">
+    <textarea name="content" class="form-control" rows="10">{{ content }}</textarea>
+  </div>
+  <button class="btn btn-primary" type="submit">Save</button>
+</form>
+{% endblock %}

--- a/note_app/templates/index.html
+++ b/note_app/templates/index.html
@@ -1,0 +1,7 @@
+{% extends 'layout.html' %}
+{% block content %}
+<div class="d-grid gap-3 mt-4">
+  <a href="/record" class="btn btn-primary btn-lg">Record Note</a>
+  <a href="/query" class="btn btn-secondary btn-lg">Query Notes</a>
+</div>
+{% endblock %}

--- a/note_app/templates/layout.html
+++ b/note_app/templates/layout.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Voice Note App</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+      body { padding-top: 56px; }
+      .sidebar { min-height: 100vh; }
+    </style>
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="/">Voice Notes</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+      </div>
+    </nav>
+    <div class="container-fluid">
+      <div class="row">
+        <nav id="sidebarMenu" class="col-md-3 col-lg-2 d-md-block bg-light sidebar collapse">
+          <div class="position-sticky pt-3">
+            <ul class="nav flex-column">
+              <li class="nav-item"><a class="nav-link" href="/notes">Notes</a></li>
+              <li class="nav-item"><a class="nav-link" href="/categories">Categories</a></li>
+            </ul>
+          </div>
+        </nav>
+        <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
+          {% block content %}{% endblock %}
+        </main>
+      </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/static/app.js"></script>
+  </body>
+</html>

--- a/note_app/templates/notes.html
+++ b/note_app/templates/notes.html
@@ -1,0 +1,10 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="mt-4">Edit Notes</h2>
+<form method="post">
+  <div class="mb-3">
+    <textarea name="content" class="form-control" rows="15">{{ content }}</textarea>
+  </div>
+  <button class="btn btn-primary" type="submit">Save</button>
+</form>
+{% endblock %}

--- a/note_app/templates/query.html
+++ b/note_app/templates/query.html
@@ -1,0 +1,11 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="mt-4">Query Notes</h2>
+<form id="query-form" class="mt-3">
+  <div class="mb-3">
+    <input type="text" class="form-control" id="query" placeholder="Enter your question">
+  </div>
+  <button class="btn btn-primary" type="submit">Submit</button>
+</form>
+<div id="query-result" class="mt-3"></div>
+{% endblock %}

--- a/note_app/templates/record.html
+++ b/note_app/templates/record.html
@@ -1,0 +1,7 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="mt-4">Record a Note</h2>
+<button id="record-btn" class="btn btn-danger mt-3">Start Recording</button>
+<p id="status" class="mt-3"></p>
+<div id="result" class="mt-3"></div>
+{% endblock %}

--- a/note_app/web_app.py
+++ b/note_app/web_app.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from flask import Flask, render_template, request, redirect, jsonify
+
+from .llm_interface import LLMInterface
+from .note_manager import NoteManager
+from .categories import load_categories
+from .voice_recorder import VoiceRecorder
+
+app = Flask(__name__)
+llm = LLMInterface()
+notes = NoteManager()
+recorder = VoiceRecorder()
+
+
+@app.route('/')
+def index() -> str:
+    return render_template('index.html')
+
+
+@app.route('/record', methods=['GET', 'POST'])
+def record() -> str | dict:
+    if request.method == 'GET':
+        return render_template('record.html')
+    audio_file = request.files.get('audio')
+    if not audio_file:
+        return jsonify({'message': 'No audio received'}), 400
+    save_path = Path('web_recording.webm')
+    audio_file.save(save_path)
+    try:
+        lang = recorder.language.split('-')[0]
+        with open(save_path, 'rb') as f:
+            response = recorder.client.audio.transcriptions.create(
+                model='whisper-1', file=f, language=lang
+            )
+        text = response.text.strip()
+        summary = llm.summarize(text)
+        category = llm.infer_category(text, load_categories())
+        notes.add_note(summary, category=category)
+        message = f"Note added: [{category}] {summary}"
+        return jsonify({'message': message})
+    finally:
+        if save_path.exists():
+            os.remove(save_path)
+
+
+@app.route('/query', methods=['GET', 'POST'])
+def query() -> str | dict:
+    if request.method == 'GET':
+        return render_template('query.html')
+    data = request.get_json()
+    if not data or 'query' not in data:
+        return jsonify({'result': 'No query provided'}), 400
+    note_text = notes.read_notes()
+    if not note_text.strip():
+        return jsonify({'result': 'No notes found'})
+    result = llm.query_notes(note_text, data['query'])
+    return jsonify({'result': result})
+
+
+def _edit_file(path: Path, content: str | None) -> str:
+    if content is not None:
+        path.write_text(content, encoding='utf-8')
+    return path.read_text(encoding='utf-8')
+
+
+@app.route('/notes', methods=['GET', 'POST'])
+def edit_notes() -> str:
+    content = None
+    if request.method == 'POST':
+        content = request.form.get('content', '')
+    text = _edit_file(Path('notes.txt'), content)
+    return render_template('notes.html', content=text)
+
+
+@app.route('/categories', methods=['GET', 'POST'])
+def edit_categories() -> str:
+    content = None
+    if request.method == 'POST':
+        content = request.form.get('content', '')
+    text = _edit_file(Path('categories.txt'), content)
+    return render_template('categories.html', content=text)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,5 +13,6 @@ dependencies = [
     "SpeechRecognition>=3.10.0",
     "PyAudio>=0.2.14",
     "python-dotenv>=1.0.0",
+    "Flask>=2.2.0",
 ]
 


### PR DESCRIPTION
## Summary
- add a minimal Flask-based web interface
- edit notes and categories from the browser
- include Bootstrap-based templates and JavaScript for recording
- mention web app in the README
- add Flask to dependencies

## Testing
- `python -m py_compile note_app/web_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68482af62d908330a72cad0ad244055c