### PR TITLE
Add language picker and instant recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,14 @@ You can run a simple web interface using Flask:
 python -m note_app.web_app
 ```
 
-Open <http://localhost:5000> in your browser. The site has two main actions:
+Open <http://localhost:5000> in your browser. Use the language selector in the
+navigation bar to choose between English and French transcription. The main page
+lets you record notes or voice queries directly without navigating to a new
+screen. Click once to start recording and again to stop. While recording the
+button turns red and shows "Recording...".
 
-- **Record Note** – record directly in the browser. The audio is sent to the
-  server, transcribed using Whisper and saved like the command line version.
-- **Query Notes** – ask questions about your notes.
+The sidebar still provides pages to edit `notes.txt` and `categories.txt`
+directly in the browser.
 
 The sidebar lets you edit `notes.txt` and `categories.txt` directly in the
 browser. The layout uses Bootstrap so it works well on mobile devices.

--- a/note_app/templates/index.html
+++ b/note_app/templates/index.html
@@ -1,7 +1,9 @@
 {% extends 'layout.html' %}
 {% block content %}
 <div class="d-grid gap-3 mt-4">
-  <a href="/record" class="btn btn-primary btn-lg">Record Note</a>
-  <a href="/query" class="btn btn-secondary btn-lg">Query Notes</a>
+  <button id="record-btn" class="btn btn-primary btn-lg">Record Note</button>
+  <div id="record-result" class="mt-2"></div>
+  <button id="query-btn" class="btn btn-secondary btn-lg">Query Notes</button>
+  <div id="query-result" class="mt-2"></div>
 </div>
 {% endblock %}

--- a/note_app/templates/layout.html
+++ b/note_app/templates/layout.html
@@ -14,6 +14,10 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
       <div class="container-fluid">
         <a class="navbar-brand" href="/">Voice Notes</a>
+        <select id="language-select" class="form-select form-select-sm text-dark ms-3" style="width:auto;">
+          <option value="en">English</option>
+          <option value="fr">French</option>
+        </select>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>

--- a/note_app/voice_recorder.py
+++ b/note_app/voice_recorder.py
@@ -23,13 +23,11 @@ class VoiceRecorder:
         self.client = OpenAI(api_key=api_key)
 
     def _record_audio(self) -> sr.AudioData:
-        """Record audio after the user presses Enter to start and stop."""
+        """Record audio until the user presses Enter to stop."""
         with sr.Microphone() as source:
             print("Calibrating ambient noise...")
             self.recognizer.adjust_for_ambient_noise(source, duration=1)
 
-            print("Press Enter to start recording...")
-            input()
             print("Recording... press Enter to stop.")
 
             stop_event = Event()


### PR DESCRIPTION
## Summary
- let recorder start immediately in CLI
- add language selector to web interface
- allow voice query in the web app
- update front-end to record from the main page
- document the new workflow in README

## Testing
- `python -m py_compile note_app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68482d1c5bec8330bd39815c773c99f4