### PR TITLE
Handle Windows file locks in web routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ notes.txt
 build/
 *.egg-info/
 *.wav
+*.webm

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Record a new voice note (English):
 python -m note_app.main record
 ```
 Categories are inferred automatically from the note text.
-The recorder now waits for you to press **Enter** to start and again to stop,
-so it won't cut you off mid-sentence.
+Recording starts immediately and you press **Enter** to stop so it won't cut you
+off mid-sentence.
 
 For French use:
 
@@ -85,11 +85,14 @@ You can run a simple web interface using Flask:
 python -m note_app.web_app
 ```
 
-Open <http://localhost:5000> in your browser. The site has two main actions:
+Open <http://localhost:5000> in your browser. Use the language selector in the
+navigation bar to choose between English and French transcription. The main page
+lets you record notes or voice queries directly without navigating to a new
+screen. Click once to start recording and again to stop. While recording the
+button turns red and shows "Recording...".
 
-- **Record Note** – record directly in the browser. The audio is sent to the
-  server, transcribed using Whisper and saved like the command line version.
-- **Query Notes** – ask questions about your notes.
+The sidebar still provides pages to edit `notes.txt` and `categories.txt`
+directly in the browser.
 
 The sidebar lets you edit `notes.txt` and `categories.txt` directly in the
 browser. The layout uses Bootstrap so it works well on mobile devices.

--- a/note_app/static/app.js
+++ b/note_app/static/app.js
@@ -1,34 +1,65 @@
-// Recording functionality
-const recordBtn = document.getElementById('record-btn');
-if (recordBtn) {
+// Language selector
+const langSelect = document.getElementById('language-select');
+if (langSelect) {
+  const saved = localStorage.getItem('language') || 'en';
+  langSelect.value = saved;
+  langSelect.addEventListener('change', () => {
+    localStorage.setItem('language', langSelect.value);
+  });
+}
+
+function setupRecorder(buttonId, endpoint, resultId) {
+  const btn = document.getElementById(buttonId);
+  if (!btn) return;
   let mediaRecorder;
   let chunks = [];
-  recordBtn.addEventListener('click', async () => {
+  let stream;
+
+  btn.addEventListener('click', async () => {
     if (!mediaRecorder || mediaRecorder.state === 'inactive') {
       chunks = [];
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       mediaRecorder = new MediaRecorder(stream);
       mediaRecorder.ondataavailable = e => chunks.push(e.data);
       mediaRecorder.onstop = async () => {
         const blob = new Blob(chunks, { type: 'audio/webm' });
-        document.getElementById('status').textContent = 'Transcribing...';
-        const fd = new FormData();
-        fd.append('audio', blob, 'recording.webm');
-        const resp = await fetch('/record', { method: 'POST', body: fd });
-        const data = await resp.json();
-        document.getElementById('status').textContent = '';
-        document.getElementById('result').textContent = data.message;
+        if (stream) stream.getTracks().forEach(t => t.stop());
+        let data = {};
+        try {
+          const fd = new FormData();
+          fd.append('audio', blob, 'recording.webm');
+          fd.append('language', localStorage.getItem('language') || 'en');
+          const resp = await fetch(endpoint, { method: 'POST', body: fd });
+          data = await resp.json();
+        } catch (err) {
+          console.error('Upload failed', err);
+          data = { message: 'Error processing recording' };
+        } finally {
+          btn.classList.remove('btn-danger');
+          btn.textContent = btn.dataset.original;
+        }
+        const resultEl = document.getElementById(resultId);
+        if (resultEl) resultEl.textContent = data.message || data.result || '';
+        mediaRecorder = null;
       };
       mediaRecorder.start();
-      recordBtn.textContent = 'Stop Recording';
+      btn.dataset.original = btn.textContent;
+      btn.textContent = 'Recording... Press again to stop';
+      btn.classList.add('btn-danger');
     } else {
+      btn.classList.remove('btn-danger');
+      btn.textContent = btn.dataset.original;
       mediaRecorder.stop();
-      recordBtn.textContent = 'Start Recording';
     }
   });
 }
 
-// Query functionality
+const recordResultId = document.getElementById('record-result') ? 'record-result' : 'result';
+const queryResultId = document.getElementById('query-result') ? 'query-result' : 'result';
+setupRecorder('record-btn', '/record', recordResultId);
+setupRecorder('query-btn', '/query', queryResultId);
+
+// Fallback typed query form
 const queryForm = document.getElementById('query-form');
 if (queryForm) {
   queryForm.addEventListener('submit', async (e) => {
@@ -40,6 +71,7 @@ if (queryForm) {
       body: JSON.stringify({ query })
     });
     const data = await resp.json();
-    document.getElementById('query-result').textContent = data.result;
+    const resultEl = document.getElementById('query-result') || document.getElementById('result');
+    if (resultEl) resultEl.textContent = data.result;
   });
 }

--- a/note_app/templates/index.html
+++ b/note_app/templates/index.html
@@ -1,7 +1,9 @@
 {% extends 'layout.html' %}
 {% block content %}
 <div class="d-grid gap-3 mt-4">
-  <a href="/record" class="btn btn-primary btn-lg">Record Note</a>
-  <a href="/query" class="btn btn-secondary btn-lg">Query Notes</a>
+  <button id="record-btn" class="btn btn-primary btn-lg">Record Note</button>
+  <div id="record-result" class="mt-2"></div>
+  <button id="query-btn" class="btn btn-secondary btn-lg">Query Notes</button>
+  <div id="query-result" class="mt-2"></div>
 </div>
 {% endblock %}

--- a/note_app/templates/layout.html
+++ b/note_app/templates/layout.html
@@ -14,6 +14,10 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
       <div class="container-fluid">
         <a class="navbar-brand" href="/">Voice Notes</a>
+        <select id="language-select" class="form-select form-select-sm text-dark ms-3" style="width:auto;">
+          <option value="en">English</option>
+          <option value="fr">French</option>
+        </select>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>

--- a/note_app/voice_recorder.py
+++ b/note_app/voice_recorder.py
@@ -23,13 +23,11 @@ class VoiceRecorder:
         self.client = OpenAI(api_key=api_key)
 
     def _record_audio(self) -> sr.AudioData:
-        """Record audio after the user presses Enter to start and stop."""
+        """Record audio until the user presses Enter to stop."""
         with sr.Microphone() as source:
             print("Calibrating ambient noise...")
             self.recognizer.adjust_for_ambient_noise(source, duration=1)
 
-            print("Press Enter to start recording...")
-            input()
             print("Recording... press Enter to stop.")
 
             stop_event = Event()

--- a/note_app/web_app.py
+++ b/note_app/web_app.py
@@ -28,13 +28,14 @@ def record() -> str | dict:
     audio_file = request.files.get('audio')
     if not audio_file:
         return jsonify({'message': 'No audio received'}), 400
+    language = request.form.get('language', 'en')
     save_path = Path('web_recording.webm')
     audio_file.save(save_path)
+    audio_file.close()
     try:
-        lang = recorder.language.split('-')[0]
         with open(save_path, 'rb') as f:
             response = recorder.client.audio.transcriptions.create(
-                model='whisper-1', file=f, language=lang
+                model='whisper-1', file=f, language=language
             )
         text = response.text.strip()
         summary = llm.summarize(text)
@@ -42,6 +43,8 @@ def record() -> str | dict:
         notes.add_note(summary, category=category)
         message = f"Note added: [{category}] {summary}"
         return jsonify({'message': message})
+    except Exception as exc:
+        return jsonify({'message': str(exc)}), 500
     finally:
         if save_path.exists():
             os.remove(save_path)
@@ -51,13 +54,33 @@ def record() -> str | dict:
 def query() -> str | dict:
     if request.method == 'GET':
         return render_template('query.html')
-    data = request.get_json()
-    if not data or 'query' not in data:
-        return jsonify({'result': 'No query provided'}), 400
+    if 'audio' in request.files:
+        audio_file = request.files['audio']
+        language = request.form.get('language', 'en')
+        save_path = Path('query_recording.webm')
+        audio_file.save(save_path)
+        audio_file.close()
+        try:
+            with open(save_path, 'rb') as f:
+                response = recorder.client.audio.transcriptions.create(
+                    model='whisper-1', file=f, language=language
+                )
+            query_text = response.text.strip()
+        except Exception as exc:
+            return jsonify({'result': str(exc)}), 500
+        finally:
+            if save_path.exists():
+                os.remove(save_path)
+    else:
+        data = request.get_json()
+        if not data or 'query' not in data:
+            return jsonify({'result': 'No query provided'}), 400
+        query_text = data['query']
+
     note_text = notes.read_notes()
     if not note_text.strip():
         return jsonify({'result': 'No notes found'})
-    result = llm.query_notes(note_text, data['query'])
+    result = llm.query_notes(note_text, query_text)
     return jsonify({'result': result})
 
 


### PR DESCRIPTION
## Summary
- add `.webm` files to .gitignore
- update README about starting recording immediately
- improve recording button so it resets as soon as it is pressed again
- close uploaded files before deleting to avoid Windows permission errors

## Testing
- `python -m py_compile note_app/*.py openai_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68482d1c5bec8330bd39815c773c99f4