### PR TITLE
Fix newline duplication when editing notes

### DIFF
--- a/note_app/web_app.py
+++ b/note_app/web_app.py
@@ -86,7 +86,8 @@ def query() -> str | dict:
 
 def _edit_file(path: Path, content: str | None) -> str:
     if content is not None:
-        path.write_text(content, encoding='utf-8')
+        normalized = content.replace('\r\n', '\n')
+        path.write_text(normalized, encoding='utf-8')
     return path.read_text(encoding='utf-8')
 
 


### PR DESCRIPTION
## Summary
- normalize Windows line endings before saving notes

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6848332f30848330a553d34fb311e2df