### PR TITLE
Improve debugging info and query display

### DIFF
--- a/note_app/static/app.js
+++ b/note_app/static/app.js
@@ -39,7 +39,11 @@ function setupRecorder(buttonId, endpoint, resultId) {
           btn.textContent = btn.dataset.original;
         }
         const resultEl = document.getElementById(resultId);
-        if (resultEl) resultEl.textContent = data.message || data.result || '';
+        if (resultEl) {
+          let msg = data.message || data.result || '';
+          if (data.debug) msg += '\n' + data.debug;
+          resultEl.textContent = msg;
+        }
         mediaRecorder = null;
       };
       mediaRecorder.start();
@@ -72,6 +76,10 @@ if (queryForm) {
     });
     const data = await resp.json();
     const resultEl = document.getElementById('query-result') || document.getElementById('result');
-    if (resultEl) resultEl.textContent = data.result;
+    if (resultEl) {
+      let msg = data.message || data.result || '';
+      if (data.debug) msg += '\n' + data.debug;
+      resultEl.textContent = msg;
+    }
   });
 }

--- a/note_app/templates/index.html
+++ b/note_app/templates/index.html
@@ -2,8 +2,8 @@
 {% block content %}
 <div class="d-grid gap-3 mt-4">
   <button id="record-btn" class="btn btn-primary btn-lg">Record Note</button>
-  <div id="record-result" class="mt-2"></div>
+  <div id="record-result" class="mt-2" style="white-space: pre-line;"></div>
   <button id="query-btn" class="btn btn-secondary btn-lg">Query Notes</button>
-  <div id="query-result" class="mt-2"></div>
+  <div id="query-result" class="mt-2" style="white-space: pre-line;"></div>
 </div>
 {% endblock %}

--- a/note_app/templates/query.html
+++ b/note_app/templates/query.html
@@ -7,5 +7,5 @@
   </div>
   <button class="btn btn-primary" type="submit">Submit</button>
 </form>
-<div id="query-result" class="mt-3"></div>
+<div id="query-result" class="mt-3" style="white-space: pre-line;"></div>
 {% endblock %}

--- a/note_app/templates/record.html
+++ b/note_app/templates/record.html
@@ -3,5 +3,5 @@
 <h2 class="mt-4">Record a Note</h2>
 <button id="record-btn" class="btn btn-danger mt-3">Start Recording</button>
 <p id="status" class="mt-3"></p>
-<div id="result" class="mt-3"></div>
+<div id="result" class="mt-3" style="white-space: pre-line;"></div>
 {% endblock %}

--- a/note_app/web_app.py
+++ b/note_app/web_app.py
@@ -45,7 +45,8 @@ def record() -> str | dict:
         category = llm.infer_category(text, load_categories())
         notes.add_note(summary, category=category)
         message = f"Note added: [{category}] {summary}"
-        return jsonify({'message': message})
+        debug = f"Transcribed text: {text}"
+        return jsonify({'message': message, 'debug': debug})
     except Exception as exc:
         return jsonify({'message': str(exc)}), 500
     finally:
@@ -84,9 +85,13 @@ def query() -> str | dict:
 
     note_text = notes.read_notes()
     if not note_text.strip():
-        return jsonify({'result': 'No notes found'})
+        return jsonify({'result': 'No notes found', 'debug': f'Query text: {query_text}'})
+
     result = llm.query_notes(note_text, query_text)
-    return jsonify({'result': result})
+    if not result.strip():
+        return jsonify({'result': 'No matching notes found', 'debug': f'Query text: {query_text}'})
+
+    return jsonify({'result': result, 'debug': f'Query text: {query_text}'})
 
 
 def _edit_file(path: Path, content: str | None) -> str:


### PR DESCRIPTION
## Summary
- show the transcribed text in responses for both recording and querying
- report when no notes or matching results are found
- display debug info on the frontend
- preserve line breaks in query results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848370441b88330bfb067eb10086dea