### PR TITLE
Add Streamlit interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,23 +79,15 @@ control how your notes are classified.
 
 ## Web Interface
 
-You can run a simple web interface using Flask:
+You can run a simple web interface using **Streamlit**:
 
 ```bash
-python -m note_app.web_app
+streamlit run note_app/streamlit_app.py
 ```
 
-Open <http://localhost:5000> in your browser. Use the language selector in the
-navigation bar to choose between English and French transcription. The main page
-lets you record notes or voice queries directly without navigating to a new
-screen. Click once to start recording and again to stop. While recording the
-button turns red and shows "Recording...".
-
-The sidebar still provides pages to edit `notes.txt` and `categories.txt`
-directly in the browser.
-
-The sidebar lets you edit `notes.txt` and `categories.txt` directly in the
-browser. The layout uses Bootstrap so it works well on mobile devices.
+Open the provided URL in your browser. The interface offers tabs to record new
+notes, query existing ones and edit `notes.txt` or `categories.txt` directly in
+the browser.
 
 ## Testing the OpenAI API
 

--- a/note_app/streamlit_app.py
+++ b/note_app/streamlit_app.py
@@ -1,0 +1,98 @@
+import os
+import tempfile
+from pathlib import Path
+
+import streamlit as st
+
+from .llm_interface import LLMInterface
+from .note_manager import NoteManager
+from .categories import load_categories
+from .voice_recorder import VoiceRecorder
+
+
+llm = LLMInterface()
+notes = NoteManager()
+recorder = VoiceRecorder()
+
+st.set_page_config(page_title="AI Note App")
+st.title("AI Voice Note App")
+
+
+def transcribe_audio(uploaded_file: Path | None, language: str) -> str:
+    """Return transcribed text from an uploaded audio file."""
+    if uploaded_file is None:
+        return ""
+    with tempfile.NamedTemporaryFile(delete=False, suffix=Path(uploaded_file.name).suffix) as tmp:
+        tmp.write(uploaded_file.getbuffer())
+        tmp_path = Path(tmp.name)
+    try:
+        with open(tmp_path, "rb") as f:
+            response = recorder.client.audio.transcriptions.create(
+                model="whisper-1", file=f, language=language
+            )
+        return response.text.strip()
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+record_tab, query_tab, notes_tab, categories_tab = st.tabs(
+    ["Record Note", "Query Notes", "Notes", "Categories"]
+)
+
+
+with record_tab:
+    st.header("Record a new note")
+    language = st.selectbox("Language", ["en", "fr"], index=0)
+    audio_file = st.file_uploader("Upload audio", type=["wav", "mp3", "m4a", "webm"])
+    text_input = st.text_area("Or enter text")
+    if st.button("Add Note"):
+        if audio_file:
+            text = transcribe_audio(audio_file, language)
+        else:
+            text = text_input.strip()
+        if not text:
+            st.error("Please provide audio or text input")
+        else:
+            summary = llm.summarize(text)
+            category = llm.infer_category(text, load_categories())
+            notes.add_note(summary, category=category)
+            st.success(f"Note added: [{category}] {summary}")
+
+
+with query_tab:
+    st.header("Query notes")
+    language = st.selectbox("Language", ["en", "fr"], index=0, key="query_lang")
+    audio_query = st.file_uploader("Upload audio", type=["wav", "mp3", "m4a", "webm"], key="query_audio")
+    query_text = st.text_input("Or type your query", key="query_text")
+    if st.button("Search"):
+        if audio_query:
+            query = transcribe_audio(audio_query, language)
+        else:
+            query = query_text.strip()
+        if not query:
+            st.error("Please provide audio or text input")
+        else:
+            note_text = notes.read_notes()
+            if not note_text.strip():
+                st.warning("No notes found")
+            else:
+                result = llm.query_notes(note_text, query)
+                st.text_area("Result", value=result, height=200)
+
+
+with notes_tab:
+    st.header("Edit notes.txt")
+    content = Path("notes.txt").read_text(encoding="utf-8")
+    edited = st.text_area("Notes", value=content, height=300)
+    if st.button("Save Notes"):
+        Path("notes.txt").write_text(edited.replace("\r\n", "\n"), encoding="utf-8")
+        st.success("Notes saved")
+
+
+with categories_tab:
+    st.header("Edit categories.txt")
+    content = Path("categories.txt").read_text(encoding="utf-8")
+    edited = st.text_area("Categories", value=content, height=300, key="cat_text")
+    if st.button("Save Categories"):
+        Path("categories.txt").write_text(edited.replace("\r\n", "\n"), encoding="utf-8")
+        st.success("Categories saved")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,5 +14,6 @@ dependencies = [
     "PyAudio>=0.2.14",
     "python-dotenv>=1.0.0",
     "Flask>=2.2.0",
+    "streamlit>=1.30.0",
 ]
 


### PR DESCRIPTION
## Summary
- add a Streamlit-based UI for recording and querying notes
- document Streamlit usage in the README
- include streamlit in the project dependencies

## Testing
- `python -m py_compile note_app/streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6848391b90348330bcea3692c9523a4e