### PR TITLE
Add mic recorder interface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "Flask>=2.2.0",
     "streamlit>=1.30.0",
+    "streamlit-mic-recorder>=0.0.8",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- integrate streamlit-mic-recorder
- simplify Streamlit UI to use hold‑to‑record buttons for adding and querying notes
- keep note and category editors under expanders

## Testing
- `python -m pip check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68495022bf5c8330813ba1f4db7f189a