### PR TITLE
Improve web UI styling and instructions

### DIFF
--- a/note_app/static/app.js
+++ b/note_app/static/app.js
@@ -48,7 +48,7 @@ function setupRecorder(buttonId, endpoint, resultId) {
       };
       mediaRecorder.start();
       btn.dataset.original = btn.textContent;
-      btn.textContent = 'Recording... Press again to stop';
+      btn.textContent = 'Recording... Click again to stop and send';
       btn.classList.add('btn-danger');
     } else {
       btn.classList.remove('btn-danger');

--- a/note_app/static/style.css
+++ b/note_app/static/style.css
@@ -1,0 +1,30 @@
+body {
+  padding-top: 56px;
+  font-family: 'Poppins', sans-serif;
+  background-color: #f0f4f8;
+}
+.sidebar {
+  min-height: 100vh;
+}
+.btn-record {
+  background-color: #ff6b6b;
+  border-radius: 30px;
+  font-weight: 600;
+  color: #fff;
+  border: none;
+}
+.btn-record:hover {
+  background-color: #ff8787;
+  color: #fff;
+}
+.btn-query {
+  background-color: #1e90ff;
+  border-radius: 30px;
+  font-weight: 600;
+  color: #fff;
+  border: none;
+}
+.btn-query:hover {
+  background-color: #58a8ff;
+  color: #fff;
+}

--- a/note_app/streamlit_app.py
+++ b/note_app/streamlit_app.py
@@ -27,6 +27,26 @@ recorder = VoiceRecorder()
 st.set_page_config(page_title="AI Note App")
 st.title("AI Voice Note App")
 
+# Inject custom styles and fonts
+st.markdown(
+    """
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Poppins', sans-serif;
+            background-color: #f0f4f8;
+        }
+        button.myButton {
+            border-radius: 30px;
+            font-weight: 600;
+            color: #fff;
+            border: none;
+        }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
 
 def transcribe_audio(data: Any, language: str) -> str:
     """Return transcribed text from uploaded data or raw bytes."""
@@ -55,8 +75,8 @@ language = st.selectbox("Language", ["en", "fr"], index=1)
 
 st.subheader("Send a note")
 note_audio = mic.mic_recorder(
-    start_prompt="Hold to record note",
-    stop_prompt="Release to send",
+    start_prompt="Click to record note",
+    stop_prompt="Click again to stop and save",
     key="note_rec",
 )
 if note_audio:
@@ -75,8 +95,8 @@ st.divider()
 
 st.subheader("Search notes")
 query_audio = mic.mic_recorder(
-    start_prompt="Hold to record query",
-    stop_prompt="Release to search",
+    start_prompt="Click to record query",
+    stop_prompt="Click again to search",
     key="query_rec",
 )
 if query_audio:
@@ -94,6 +114,25 @@ if query_audio:
         st.session_state["query_result"] = "Could not understand audio."
 if "query_result" in st.session_state:
     st.text_area("Result", value=st.session_state["query_result"], height=200)
+
+# Color-code the microphone buttons after they are rendered
+st.markdown(
+    """
+    <script>
+    function styleButtons() {
+      const btns = document.querySelectorAll('button.myButton');
+      if (btns.length >= 2) {
+        btns[0].style.backgroundColor = '#ff6b6b';
+        btns[1].style.backgroundColor = '#1e90ff';
+      } else {
+        setTimeout(styleButtons, 100);
+      }
+    }
+    styleButtons();
+    </script>
+    """,
+    unsafe_allow_html=True,
+)
 
 with st.expander("Edit notes.txt"):
     content = Path("notes.txt").read_text(encoding="utf-8")

--- a/note_app/templates/index.html
+++ b/note_app/templates/index.html
@@ -1,9 +1,9 @@
 {% extends 'layout.html' %}
 {% block content %}
 <div class="d-grid gap-3 mt-4">
-  <button id="record-btn" class="btn btn-primary btn-lg">Record Note</button>
+  <button id="record-btn" class="btn btn-record btn-lg">Start Recording</button>
   <div id="record-result" class="mt-2" style="white-space: pre-line;"></div>
-  <button id="query-btn" class="btn btn-secondary btn-lg">Query Notes</button>
+  <button id="query-btn" class="btn btn-query btn-lg">Voice Query</button>
   <div id="query-result" class="mt-2" style="white-space: pre-line;"></div>
 </div>
 {% endblock %}

--- a/note_app/templates/layout.html
+++ b/note_app/templates/layout.html
@@ -5,10 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Voice Note App</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    <style>
-      body { padding-top: 56px; }
-      .sidebar { min-height: 100vh; }
-    </style>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link href="/static/style.css" rel="stylesheet">
   </head>
   <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">

--- a/note_app/templates/query.html
+++ b/note_app/templates/query.html
@@ -5,7 +5,7 @@
   <div class="mb-3">
     <input type="text" class="form-control" id="query" placeholder="Enter your question">
   </div>
-  <button class="btn btn-primary" type="submit">Submit</button>
+  <button class="btn btn-query" type="submit">Submit</button>
 </form>
 <div id="query-result" class="mt-3" style="white-space: pre-line;"></div>
 {% endblock %}

--- a/note_app/templates/record.html
+++ b/note_app/templates/record.html
@@ -1,7 +1,7 @@
 {% extends 'layout.html' %}
 {% block content %}
 <h2 class="mt-4">Record a Note</h2>
-<button id="record-btn" class="btn btn-danger mt-3">Start Recording</button>
+<button id="record-btn" class="btn btn-record mt-3">Start Recording</button>
 <p id="status" class="mt-3"></p>
 <div id="result" class="mt-3" style="white-space: pre-line;"></div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- clarify the recording button text
- add custom style sheet and Google font
- color-code the Record and Query buttons
- style the Streamlit interface with matching colors

## Testing
- `python openai_test.py` *(fails: OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_684962eb3ae88330bce32a254c768eb4